### PR TITLE
Fix: Invalid ShortGuids Must not Return True in TryParse

### DIFF
--- a/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
+++ b/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
@@ -1,4 +1,4 @@
-﻿using CSharpVitamins;
+using CSharpVitamins;
 using System;
 using Xunit;
 
@@ -22,6 +22,12 @@ namespace Tests
             var actual = new ShortGuid(SampleShortGuidString);
 
             assert_instance_equals_samples(actual);
+        }
+
+        [Fact]
+        void invalid_strings_must_not_return_true_on_try_parse()
+        {
+            Assert.False(ShortGuid.TryParse("bullshitmustnotbevalid", out ShortGuid _));
         }
 
         [Fact]

--- a/CSharpVitamins.ShortGuid/ShortGuid.cs
+++ b/CSharpVitamins.ShortGuid/ShortGuid.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 
 namespace CSharpVitamins
@@ -294,16 +294,16 @@ namespace CSharpVitamins
         public static bool TryParse(string value, out ShortGuid shortGuid)
         {
             // Try a ShortGuid string.
-            if (ShortGuid.TryDecode(value, out var guid))
+            if (ShortGuid.TryDecode(value, out Guid decodedGuid) && ((ShortGuid)decodedGuid).Value == value)
             {
-                shortGuid = guid;
+                shortGuid = decodedGuid;
                 return true;
             }
 
             // Try a Guid string.
-            if (Guid.TryParse(value, out guid))
+            if (Guid.TryParse(value, out Guid guid))
             {
-                shortGuid = guid;
+                shortGuid = new ShortGuid(guid);
                 return true;
             }
 


### PR DESCRIPTION
The TryParse method sometimes returns true although the parsed argument is no valid ShortGuid. I found this to be counterintuitive. This PR adds a test case that demonstrates the behaviour and a fix addressing the issue in the TryParse method.