### PR TITLE
Feature/add strict flag to decode

### DIFF
--- a/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
+++ b/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
@@ -1,23 +1,25 @@
 ﻿using CSharpVitamins;
+
 using System;
+
 using Xunit;
 
 namespace Tests
 {
     public class ShortGuidFacts
     {
-        const string SampleGuidString = "c9a646d3-9c61-4cb7-bfcd-ee2522c8f633";
-        static readonly Guid SampleGuid = new Guid(SampleGuidString);
-        const string SampleShortGuidString = "00amyWGct0y_ze4lIsj2Mw";
+        private const string SampleGuidString = "c9a646d3-9c61-4cb7-bfcd-ee2522c8f633";
+        private static readonly Guid SampleGuid = new Guid(SampleGuidString);
+        private const string SampleShortGuidString = "00amyWGct0y_ze4lIsj2Mw";
 
-        void assert_instance_equals_samples(ShortGuid instance)
+        private void assert_instance_equals_samples(ShortGuid instance)
         {
             Assert.Equal(SampleShortGuidString, instance.Value);
             Assert.Equal(SampleGuid, instance.Guid);
         }
 
         [Fact]
-        void ctor_decodes_shortguid_string()
+        private void ctor_decodes_shortguid_string()
         {
             var actual = new ShortGuid(SampleShortGuidString);
 
@@ -25,7 +27,14 @@ namespace Tests
         }
 
         [Fact]
-        void ctor_throws_when_trying_to_decode_guid_string()
+        private void invalid_strings_must_not_return_true_on_try_parse()
+        {
+            Assert.True(ShortGuid.TryParse("bullshitmustnotbevalid", out ShortGuid _, strict: false));
+            Assert.False(ShortGuid.TryParse("bullshitmustnotbevalid", out ShortGuid _, strict: true));
+        }
+
+        [Fact]
+        private void ctor_throws_when_trying_to_decode_guid_string()
         {
             Assert.Throws<FormatException>(
                 () => new ShortGuid(SampleGuidString)
@@ -33,7 +42,7 @@ namespace Tests
         }
 
         [Fact]
-        void TryParse_decodes_shortguid_string()
+        private void TryParse_decodes_shortguid_string()
         {
             ShortGuid.TryParse(SampleShortGuidString, out ShortGuid actual);
 
@@ -41,7 +50,7 @@ namespace Tests
         }
 
         [Fact]
-        void TryParse_decodes_guid_string()
+        private void TryParse_decodes_guid_string()
         {
             ShortGuid.TryParse(SampleGuidString, out ShortGuid actual);
 
@@ -49,7 +58,7 @@ namespace Tests
         }
 
         [Fact]
-        void TryParse_decodes_empty_guid_literal_as_empty()
+        private void TryParse_decodes_empty_guid_literal_as_empty()
         {
             bool result = ShortGuid.TryParse(Guid.Empty.ToString(), out ShortGuid actual);
 
@@ -58,7 +67,7 @@ namespace Tests
         }
 
         [Fact]
-        void TryParse_decodes_empty_string_as_empty()
+        private void TryParse_decodes_empty_string_as_empty()
         {
             bool result = ShortGuid.TryParse(string.Empty, out ShortGuid actual);
 
@@ -67,7 +76,7 @@ namespace Tests
         }
 
         [Fact]
-        void TryParse_decodes_bad_string_as_empty()
+        private void TryParse_decodes_bad_string_as_empty()
         {
             bool result = ShortGuid.TryParse("Nothing to see here...", out ShortGuid actual);
 
@@ -76,7 +85,7 @@ namespace Tests
         }
 
         [Fact]
-        void Encode_creates_expected_string()
+        private void Encode_creates_expected_string()
         {
             string actual = ShortGuid.Encode(SampleGuid);
 
@@ -84,7 +93,7 @@ namespace Tests
         }
 
         [Fact]
-        void Decode_takes_expected_string()
+        private void Decode_takes_expected_string()
         {
             Guid actual = ShortGuid.Decode(SampleShortGuidString);
 
@@ -92,7 +101,7 @@ namespace Tests
         }
 
         [Fact]
-        void Decode_fails_on_unexpected_string()
+        private void Decode_fails_on_unexpected_string()
         {
             Assert.Throws<FormatException>(
                 () => ShortGuid.Decode("Am I valid?")
@@ -100,7 +109,7 @@ namespace Tests
         }
 
         [Fact]
-        void instance_equality_equals()
+        private void instance_equality_equals()
         {
             var actual = new ShortGuid(SampleShortGuidString);
 
@@ -112,7 +121,7 @@ namespace Tests
         }
 
         [Fact]
-        void operator_eqaulity_equals()
+        private void operator_eqaulity_equals()
         {
             ShortGuid actual = new ShortGuid(SampleShortGuidString);
 
@@ -132,7 +141,7 @@ namespace Tests
         }
 
         [Fact]
-        void ShortGuid_Emtpy_equals_Guid_Empty()
+        private void ShortGuid_Emtpy_equals_Guid_Empty()
         {
             Assert.True(Guid.Empty.Equals(ShortGuid.Empty));
         }

--- a/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
+++ b/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
@@ -25,6 +25,18 @@ namespace Tests
         }
 
         [Fact]
+        void StrictDecode_parses_valid_shortGuid_strict_off()
+        {
+            ShortGuid.Decode(SampleShortGuidString, strict: false);
+        }
+
+        [Fact]
+        void StrictDecode_parses_valid_shortGuid_strict_on()
+        {
+            ShortGuid.Decode(SampleShortGuidString, strict: true);
+        }
+
+        [Fact]
         void invalid_strings_must_not_return_true_on_try_parse_with_strict_true()
         {
             var base64String = "bullshitmustnotbevalid";

--- a/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
+++ b/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
@@ -1,4 +1,4 @@
-using CSharpVitamins;
+﻿using CSharpVitamins;
 using System;
 using Xunit;
 
@@ -22,12 +22,6 @@ namespace Tests
             var actual = new ShortGuid(SampleShortGuidString);
 
             assert_instance_equals_samples(actual);
-        }
-
-        [Fact]
-        void invalid_strings_must_not_return_true_on_try_parse()
-        {
-            Assert.False(ShortGuid.TryParse("bullshitmustnotbevalid", out ShortGuid _));
         }
 
         [Fact]

--- a/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
+++ b/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
@@ -1,25 +1,23 @@
 ﻿using CSharpVitamins;
-
 using System;
-
 using Xunit;
 
 namespace Tests
 {
     public class ShortGuidFacts
     {
-        private const string SampleGuidString = "c9a646d3-9c61-4cb7-bfcd-ee2522c8f633";
-        private static readonly Guid SampleGuid = new Guid(SampleGuidString);
-        private const string SampleShortGuidString = "00amyWGct0y_ze4lIsj2Mw";
+        const string SampleGuidString = "c9a646d3-9c61-4cb7-bfcd-ee2522c8f633";
+        static readonly Guid SampleGuid = new Guid(SampleGuidString);
+        const string SampleShortGuidString = "00amyWGct0y_ze4lIsj2Mw";
 
-        private void assert_instance_equals_samples(ShortGuid instance)
+        void assert_instance_equals_samples(ShortGuid instance)
         {
             Assert.Equal(SampleShortGuidString, instance.Value);
             Assert.Equal(SampleGuid, instance.Guid);
         }
 
         [Fact]
-        private void ctor_decodes_shortguid_string()
+        void ctor_decodes_shortguid_string()
         {
             var actual = new ShortGuid(SampleShortGuidString);
 
@@ -27,7 +25,7 @@ namespace Tests
         }
 
         [Fact]
-        private void invalid_strings_must_not_return_true_on_try_parse_with_strict_true()
+        void invalid_strings_must_not_return_true_on_try_parse_with_strict_true()
         {
             var base64String = "bullshitmustnotbevalid";
             Assert.True(ShortGuid.TryParse(base64String, out ShortGuid shortGuidA)); // strict defaults to false
@@ -38,7 +36,7 @@ namespace Tests
         }
 
         [Fact]
-        private void ctor_throws_when_trying_to_decode_guid_string()
+        void ctor_throws_when_trying_to_decode_guid_string()
         {
             Assert.Throws<FormatException>(
                 () => new ShortGuid(SampleGuidString)
@@ -46,7 +44,7 @@ namespace Tests
         }
 
         [Fact]
-        private void TryParse_decodes_shortguid_string()
+        void TryParse_decodes_shortguid_string()
         {
             ShortGuid.TryParse(SampleShortGuidString, out ShortGuid actual);
 
@@ -54,7 +52,7 @@ namespace Tests
         }
 
         [Fact]
-        private void TryParse_decodes_guid_string()
+        void TryParse_decodes_guid_string()
         {
             ShortGuid.TryParse(SampleGuidString, out ShortGuid actual);
 
@@ -62,7 +60,7 @@ namespace Tests
         }
 
         [Fact]
-        private void TryParse_decodes_empty_guid_literal_as_empty()
+        void TryParse_decodes_empty_guid_literal_as_empty()
         {
             bool result = ShortGuid.TryParse(Guid.Empty.ToString(), out ShortGuid actual);
 
@@ -71,7 +69,7 @@ namespace Tests
         }
 
         [Fact]
-        private void TryParse_decodes_empty_string_as_empty()
+        void TryParse_decodes_empty_string_as_empty()
         {
             bool result = ShortGuid.TryParse(string.Empty, out ShortGuid actual);
 
@@ -80,7 +78,7 @@ namespace Tests
         }
 
         [Fact]
-        private void TryParse_decodes_bad_string_as_empty()
+        void TryParse_decodes_bad_string_as_empty()
         {
             bool result = ShortGuid.TryParse("Nothing to see here...", out ShortGuid actual);
 
@@ -89,7 +87,7 @@ namespace Tests
         }
 
         [Fact]
-        private void Encode_creates_expected_string()
+        void Encode_creates_expected_string()
         {
             string actual = ShortGuid.Encode(SampleGuid);
 
@@ -97,7 +95,7 @@ namespace Tests
         }
 
         [Fact]
-        private void Decode_takes_expected_string()
+        void Decode_takes_expected_string()
         {
             Guid actual = ShortGuid.Decode(SampleShortGuidString);
 
@@ -105,7 +103,7 @@ namespace Tests
         }
 
         [Fact]
-        private void Decode_fails_on_unexpected_string()
+        void Decode_fails_on_unexpected_string()
         {
             Assert.Throws<FormatException>(
                 () => ShortGuid.Decode("Am I valid?")
@@ -113,7 +111,7 @@ namespace Tests
         }
 
         [Fact]
-        private void instance_equality_equals()
+        void instance_equality_equals()
         {
             var actual = new ShortGuid(SampleShortGuidString);
 
@@ -125,7 +123,7 @@ namespace Tests
         }
 
         [Fact]
-        private void operator_eqaulity_equals()
+        void operator_eqaulity_equals()
         {
             ShortGuid actual = new ShortGuid(SampleShortGuidString);
 
@@ -145,7 +143,7 @@ namespace Tests
         }
 
         [Fact]
-        private void ShortGuid_Emtpy_equals_Guid_Empty()
+        void ShortGuid_Emtpy_equals_Guid_Empty()
         {
             Assert.True(Guid.Empty.Equals(ShortGuid.Empty));
         }

--- a/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
+++ b/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
@@ -11,6 +11,11 @@ namespace Tests
         const string SampleShortGuidString = "00amyWGct0y_ze4lIsj2Mw";
 
         /// <summary>
+        /// Literal: c9a646d3-9c61-4cb7-bfcd-ee2522c8f633 and some extra chars.
+        /// </summary>
+        const string LongerBase64String = "YzlhNjQ2ZDMtOWM2MS00Y2I3LWJmY2QtZWUyNTIyYzhmNjMzIGFuZCBzb21lIGV4dHJhIGNoYXJzLg";
+
+        /// <summary>
         /// "bullshitmustnotbevalid" in this case does produce a valid Guid, which when output encodes as correctly
         /// as "bullshitmustnotbevaliQ".
         /// </summary>
@@ -40,6 +45,22 @@ namespace Tests
         void StrictDecode_parses_valid_shortGuid_strict_on()
         {
             ShortGuid.Decode(SampleShortGuidString, strict: true);
+        }
+
+        [Fact]
+        void Decode_does_not_parse_longer_base64_string()
+        {
+            Assert.Throws<ArgumentException>(
+                () => ShortGuid.Decode(LongerBase64String, strict: false)
+                );
+        }
+
+        [Fact]
+        void StrictDecode_does_not_parse_longer_base64_string()
+        {
+            Assert.Throws<ArgumentException>(
+                () => ShortGuid.Decode(LongerBase64String, strict: true)
+                );
         }
 
         [Fact]

--- a/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
+++ b/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
@@ -1,4 +1,4 @@
-﻿using CSharpVitamins;
+using CSharpVitamins;
 using System;
 using Xunit;
 
@@ -22,6 +22,12 @@ namespace Tests
             var actual = new ShortGuid(SampleShortGuidString);
 
             assert_instance_equals_samples(actual);
+        }
+
+        [Fact]
+        void invalid_strings_must_not_return_true_on_try_parse()
+        {
+            Assert.False(ShortGuid.TryParse("bullshitmustnotbevalid", out ShortGuid _));
         }
 
         [Fact]

--- a/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
+++ b/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
@@ -27,10 +27,14 @@ namespace Tests
         }
 
         [Fact]
-        private void invalid_strings_must_not_return_true_on_try_parse()
+        private void invalid_strings_must_not_return_true_on_try_parse_with_strict_true()
         {
-            Assert.True(ShortGuid.TryParse("bullshitmustnotbevalid", out ShortGuid _, strict: false));
-            Assert.False(ShortGuid.TryParse("bullshitmustnotbevalid", out ShortGuid _, strict: true));
+            var base64String = "bullshitmustnotbevalid";
+            Assert.True(ShortGuid.TryParse(base64String, out ShortGuid shortGuidA)); // strict defaults to false
+            Assert.False(ShortGuid.TryParse(base64String, out ShortGuid _, strict: true));
+            Assert.Throws<FormatException>(() => ShortGuid.Decode("bullshitmustnotbevalid", strict: true));
+            Guid guidA = ShortGuid.Decode("bullshitmustnotbevalid"); // does not throw an exception because strict defaults to false
+            Assert.Equal((Guid)shortGuidA, guidA);
         }
 
         [Fact]

--- a/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
+++ b/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
@@ -10,6 +10,12 @@ namespace Tests
         static readonly Guid SampleGuid = new Guid(SampleGuidString);
         const string SampleShortGuidString = "00amyWGct0y_ze4lIsj2Mw";
 
+        /// <summary>
+        /// "bullshitmustnotbevalid" in this case does produce a valid Guid, which when output encodes as correctly
+        /// as "bullshitmustnotbevaliQ".
+        /// </summary>
+        const string InvalidSampleShortGuidString = "bullshitmustnotbevalid";
+
         void assert_instance_equals_samples(ShortGuid instance)
         {
             Assert.Equal(SampleShortGuidString, instance.Value);
@@ -39,11 +45,10 @@ namespace Tests
         [Fact]
         void invalid_strings_must_not_return_true_on_try_parse_with_strict_true()
         {
-            var base64String = "bullshitmustnotbevalid";
-            Assert.True(ShortGuid.TryParse(base64String, out ShortGuid shortGuidA)); // strict defaults to false
-            Assert.False(ShortGuid.TryParse(base64String, out ShortGuid _, strict: true));
-            Assert.Throws<FormatException>(() => ShortGuid.Decode("bullshitmustnotbevalid", strict: true));
-            Guid guidA = ShortGuid.Decode("bullshitmustnotbevalid"); // does not throw an exception because strict defaults to false
+            Assert.True(ShortGuid.TryParse(InvalidSampleShortGuidString, out ShortGuid shortGuidA)); // strict defaults to false
+            Assert.False(ShortGuid.TryParse(InvalidSampleShortGuidString, out ShortGuid _, strict: true));
+            Assert.Throws<FormatException>(() => ShortGuid.Decode(InvalidSampleShortGuidString, strict: true));
+            Guid guidA = ShortGuid.Decode(InvalidSampleShortGuidString); // does not throw an exception because strict defaults to false
             Assert.Equal((Guid)shortGuidA, guidA);
         }
 

--- a/CSharpVitamins.ShortGuid/CSharpVitamins.ShortGuid.csproj
+++ b/CSharpVitamins.ShortGuid/CSharpVitamins.ShortGuid.csproj
@@ -12,7 +12,7 @@
     <PackageLicenseExpression></PackageLicenseExpression>
     <RepositoryUrl>https://github.com/csharpvitamins/csharpvitamins.shortguid/</RepositoryUrl>
     <PackageTags>Guid ShortGuid Identifiers Base64</PackageTags>
-    <PackageReleaseNotes>
+    <PackageReleaseNotes>- 1.0.4 Adds an optional strict=false parameter to (Try)Decode/Parse
 - 1.0.3 Improves documentation.
         Adds symbols package to enable SourceLink.
 - 1.0.2 Fix: Ambiguous use of `==` operator when comparing Guid and ShortGuid instances.
@@ -20,7 +20,7 @@
 - 1.0.0 Initial release.
 </PackageReleaseNotes>
     <Copyright>Copyright 2007</Copyright>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/CSharpVitamins.ShortGuid/CSharpVitamins.ShortGuid.csproj
+++ b/CSharpVitamins.ShortGuid/CSharpVitamins.ShortGuid.csproj
@@ -12,7 +12,8 @@
     <PackageLicenseExpression></PackageLicenseExpression>
     <RepositoryUrl>https://github.com/csharpvitamins/csharpvitamins.shortguid/</RepositoryUrl>
     <PackageTags>Guid ShortGuid Identifiers Base64</PackageTags>
-    <PackageReleaseNotes>- 1.0.4 Adds an optional strict=false parameter to (Try)Decode/Parse
+    <PackageReleaseNotes>
+- 1.0.4 Adds overloads for strict parsing to (Try)Decode/Parse methods. Default: strict=false for backwards compatibility.
 - 1.0.3 Improves documentation.
         Adds symbols package to enable SourceLink.
 - 1.0.2 Fix: Ambiguous use of `==` operator when comparing Guid and ShortGuid instances.

--- a/CSharpVitamins.ShortGuid/ShortGuid.cs
+++ b/CSharpVitamins.ShortGuid/ShortGuid.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 
 namespace CSharpVitamins
@@ -294,16 +294,16 @@ namespace CSharpVitamins
         public static bool TryParse(string value, out ShortGuid shortGuid)
         {
             // Try a ShortGuid string.
-            if (ShortGuid.TryDecode(value, out var guid))
+            if (ShortGuid.TryDecode(value, out Guid decodedGuid) && ((ShortGuid)decodedGuid).Value == value)
             {
-                shortGuid = guid;
+                shortGuid = decodedGuid;
                 return true;
             }
 
             // Try a Guid string.
-            if (Guid.TryParse(value, out guid))
+            if (Guid.TryParse(value, out Guid guid))
             {
-                shortGuid = guid;
+                shortGuid = new ShortGuid(guid);
                 return true;
             }
 

--- a/CSharpVitamins.ShortGuid/ShortGuid.cs
+++ b/CSharpVitamins.ShortGuid/ShortGuid.cs
@@ -165,7 +165,7 @@ namespace CSharpVitamins
             if (!strict)
                 return guid;
 
-            var reencodedOutput = new ShortGuid(guid).Value;
+            var reencodedOutput = Encode(guid);
             if (reencodedOutput == value)
                 return guid;
 

--- a/CSharpVitamins.ShortGuid/ShortGuid.cs
+++ b/CSharpVitamins.ShortGuid/ShortGuid.cs
@@ -155,11 +155,11 @@ namespace CSharpVitamins
         /// <exception cref="FormatException">If <paramref name="value"/> is no valid base64 string (<seealso cref="Convert.FromBase64String(string)"/>) or if the <paramref name="strict"/> flag is set and the re-encoded output doesn't match <paramref name="value"/>.</exception>
         public static Guid Decode(string value, bool strict)
         {
-            value = value
+            string base64 = value
                 .Replace("_", "/")
-                .Replace("-", "+");
+                .Replace("-", "+") + "==";
 
-            byte[] blob = Convert.FromBase64String(value + "==");
+            byte[] blob = Convert.FromBase64String(base64);
             var guid = new Guid(blob);
 
             if (!strict)

--- a/CSharpVitamins.ShortGuid/ShortGuid.cs
+++ b/CSharpVitamins.ShortGuid/ShortGuid.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 
 namespace CSharpVitamins
@@ -294,16 +294,16 @@ namespace CSharpVitamins
         public static bool TryParse(string value, out ShortGuid shortGuid)
         {
             // Try a ShortGuid string.
-            if (ShortGuid.TryDecode(value, out Guid decodedGuid) && ((ShortGuid)decodedGuid).Value == value)
+            if (ShortGuid.TryDecode(value, out var guid))
             {
-                shortGuid = decodedGuid;
+                shortGuid = guid;
                 return true;
             }
 
             // Try a Guid string.
-            if (Guid.TryParse(value, out Guid guid))
+            if (Guid.TryParse(value, out guid))
             {
-                shortGuid = new ShortGuid(guid);
+                shortGuid = guid;
                 return true;
             }
 

--- a/CSharpVitamins.ShortGuid/ShortGuid.cs
+++ b/CSharpVitamins.ShortGuid/ShortGuid.cs
@@ -27,12 +27,33 @@ namespace CSharpVitamins
         /// Creates a new instance with the given URL-safe Base64 encoded string.
         /// <para>See also <seealso cref="ShortGuid.TryParse(string, out ShortGuid)"/> which will try to coerce the
         /// the value from URL-safe Base64 or normal Guid string.</para>
+        /// 
+        /// <para>NB: This method does not check if the result Guid is strictly correct. It accepts any Base64 encoded
+        /// string, allowing a) longer strings to be parsed where the remaining data is ignored and b) the end of a
+        /// Base64 string to be tweaked where it still produces that same byte array to create the underlying Guid.
+        /// Effectively there is "unused space" in the Base64 string which is ignored.
+        /// </para>
+        /// <para>See the strict version of this method which ensures the value being passed in is valid. Strict decoding
+        /// will be on by default from version 2+.</para>
         /// </summary>
         /// <param name="value">A ShortGuid encoded string e.g. URL-safe Base64.</param>
         public ShortGuid(string value)
         {
             encodedString = value;
             underlyingGuid = Decode(value);
+        }
+
+        /// <summary>
+        /// Creates a new instance with the given URL-safe Base64 encoded string.
+        /// <para>See also <seealso cref="ShortGuid.TryParse(string, out ShortGuid)"/> which will try to coerce the
+        /// the value from URL-safe Base64 or normal Guid string.</para>
+        /// </summary>
+        /// <param name="value">A ShortGuid encoded string e.g. URL-safe Base64.</param>
+        /// /// <param name="strict">If true the re-encoded result has to exactly match the input <paramref name="value"/>; if false any valid base64 string will be accepted.</param>
+        public ShortGuid(string value, bool strict)
+        {
+            encodedString = value;
+            underlyingGuid = Decode(value, strict);
         }
 
         /// <summary>

--- a/CSharpVitamins.ShortGuid/ShortGuid.cs
+++ b/CSharpVitamins.ShortGuid/ShortGuid.cs
@@ -82,7 +82,7 @@ namespace CSharpVitamins
             if (obj is string str)
             {
                 // Try a ShortGuid string.
-                if (TryDecode(str, out guid))
+                if (TryDecode(str, out guid, strict: false))
                     return underlyingGuid.Equals(guid);
 
                 // Try a guid string.
@@ -136,13 +136,24 @@ namespace CSharpVitamins
 
         /// <summary>
         /// Decodes the given value to a <see cref="System.Guid"/>.
-        /// <para>See also <seealso cref="TryDecode(string, out Guid, bool)"/> or <seealso cref="TryParse(string, out Guid)"/>.</para>
+        /// <para>See also <seealso cref="TryDecode(string, out Guid)"/> or <seealso cref="TryParse(string, out Guid)"/>.</para>
+        /// </summary>
+        /// <param name="value">The ShortGuid encoded string to decode.</param>
+        /// <returns>A new <see cref="System.Guid"/> instance from the parsed string.</returns>
+        public static Guid Decode(string value)
+        {
+            return Decode(value, strict: false);
+        }
+
+        /// <summary>
+        /// Decodes the given value to a <see cref="System.Guid"/>.
+        /// <para>See also <seealso cref="TryDecode(string, out Guid, bool)"/> or <seealso cref="TryParse(string, out Guid, bool)"/>.</para>
         /// </summary>
         /// <param name="value">The ShortGuid encoded string to decode.</param>
         /// <param name="strict">If true the re-encoded result has to exactly match the input <paramref name="value"/>; if false any valid base64 string will be accepted.</param>
         /// <returns>A new <see cref="System.Guid"/> instance from the parsed string.</returns>
         /// <exception cref="FormatException">If <paramref name="value"/> is no valid base64 string (<seealso cref="Convert.FromBase64String(string)"/>) or if the <paramref name="strict"/> flag is set and the re-encoded output doesn't match <paramref name="value"/>.</exception>
-        public static Guid Decode(string value, bool strict = false)
+        public static Guid Decode(string value, bool strict)
         {
             value = value
                 .Replace("_", "/")
@@ -150,16 +161,42 @@ namespace CSharpVitamins
 
             byte[] blob = Convert.FromBase64String(value + "==");
             var guid = new Guid(blob);
+
             if (!strict)
-            {
                 return guid;
-            }
+
             var reencodedOutput = new ShortGuid(guid).Value;
             if (reencodedOutput == value)
-            {
                 return guid;
-            }
+
             throw new FormatException($"The string '{value}' is a valid base64 string but doesn't match the re-encoded {nameof(ShortGuid)} '{reencodedOutput}'.");
+        }
+
+        /// <summary>
+        /// Attempts to decode the given value to a <see cref="System.Guid"/>.
+        ///
+        /// <para>The difference between TryParse and TryDecode:</para>
+        /// <list type="number">
+        ///     <item>
+        ///         <term><see cref="TryParse(string, out ShortGuid)"/></term>
+        ///         <description>Tries to parse as a <see cref="ShortGuid"/> before attempting parsing as a <see cref="System.Guid"/>, outputs the actual <see cref="ShortGuid"/> instance.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="TryParse(string, out Guid)"/></term>
+        ///         <description>Tries to parse as a <see cref="ShortGuid"/> before attempting parsing as a <see cref="System.Guid"/>, outputs the underlying <see cref="System.Guid"/>.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="TryDecode(string, out Guid)"/></term>
+        ///         <description>Tries to parse as a <see cref="ShortGuid"/> only, but outputs the result as a <see cref="System.Guid"/> - this method.</description>
+        ///     </item>
+        /// </list>
+        /// </summary>
+        /// <param name="value">The ShortGuid encoded string to decode.</param>
+        /// <param name="guid">A new <see cref="System.Guid"/> instance from the parsed string.</param>
+        /// <returns>A boolean indicating if the decode was successful.</returns>
+        public static bool TryDecode(string value, out Guid guid)
+        {
+            return TryDecode(value, out guid, strict: false);
         }
 
         /// <summary>
@@ -185,7 +222,7 @@ namespace CSharpVitamins
         /// <param name="guid">A new <see cref="System.Guid"/> instance from the parsed string.</param>
         /// <param name="strict">If true the re-encoded result has to exactly match the input <paramref name="value"/>; if false any valid base64 string will be accepted.</param>
         /// <returns>A boolean indicating if the decode was successful.</returns>
-        public static bool TryDecode(string value, out Guid guid, bool strict = false)
+        public static bool TryDecode(string value, out Guid guid, bool strict)
         {
             try
             {
@@ -279,7 +316,34 @@ namespace CSharpVitamins
             return new ShortGuid(guid);
         }
 
-        #endregion Operators
+        #endregion
+
+        /// <summary>
+        /// Tries to parse the value as a <see cref="ShortGuid"/> or <see cref="System.Guid"/> string, and outputs an actual <see cref="ShortGuid"/> instance.
+        ///
+        /// <para>The difference between TryParse and TryDecode:</para>
+        /// <list type="number">
+        ///     <item>
+        ///         <term><see cref="TryParse(string, out ShortGuid)"/></term>
+        ///         <description>Tries to parse as a <see cref="ShortGuid"/> before attempting parsing as a <see cref="System.Guid"/>, outputs the actual <see cref="ShortGuid"/> instance - this method.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="TryParse(string, out Guid)"/></term>
+        ///         <description>Tries to parse as a <see cref="ShortGuid"/> before attempting parsing as a <see cref="System.Guid"/>, outputs the underlying <see cref="System.Guid"/>.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="TryDecode(string, out Guid)"/></term>
+        ///         <description>Tries to parse as a <see cref="ShortGuid"/> only, but outputs the result as a <see cref="System.Guid"/>.</description>
+        ///     </item>
+        /// </list>
+        /// </summary>
+        /// <param name="value">The ShortGuid encoded string or string representation of a Guid.</param>
+        /// <param name="shortGuid">A new <see cref="ShortGuid"/> instance from the parsed string.</param>
+        /// <returns>A boolean indicating if the parse was successful.</returns>
+        public static bool TryParse(string value, out ShortGuid shortGuid)
+        {
+            return TryParse(value, out shortGuid, strict: false);
+        }
 
         /// <summary>
         /// Tries to parse the value as a <see cref="ShortGuid"/> or <see cref="System.Guid"/> string, and outputs an actual <see cref="ShortGuid"/> instance.
@@ -304,7 +368,7 @@ namespace CSharpVitamins
         /// <param name="shortGuid">A new <see cref="ShortGuid"/> instance from the parsed string.</param>
         /// <param name="strict">If true the re-encoded result has to exactly match the input <paramref name="value"/>; if false any valid base64 string will be accepted.</param>
         /// <returns>A boolean indicating if the parse was successful.</returns>
-        public static bool TryParse(string value, out ShortGuid shortGuid, bool strict = false)
+        public static bool TryParse(string value, out ShortGuid shortGuid, bool strict)
         {
             // Try a ShortGuid string.
             if (ShortGuid.TryDecode(value, out var guid, strict))
@@ -330,6 +394,33 @@ namespace CSharpVitamins
         /// <para>The difference between TryParse and TryDecode:</para>
         /// <list type="number">
         ///     <item>
+        ///         <term><see cref="TryParse(string, out ShortGuid)"/></term>
+        ///         <description>Tries to parse as a <see cref="ShortGuid"/> before attempting parsing as a <see cref="System.Guid"/>, outputs the actual <see cref="ShortGuid"/> instance.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="TryParse(string, out Guid)"/></term>
+        ///         <description>Tries to parse as a <see cref="ShortGuid"/> before attempting parsing as a <see cref="System.Guid"/>, outputs the underlying <see cref="System.Guid"/> - this method.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="TryDecode(string, out Guid)"/></term>
+        ///         <description>Tries to parse as a <see cref="ShortGuid"/> only, but outputs the result as a <see cref="System.Guid"/>.</description>
+        ///     </item>
+        /// </list>
+        /// </summary>
+        /// <param name="value">The ShortGuid encoded string or string representation of a Guid.</param>
+        /// <param name="guid">A new <see cref="System.Guid"/> instance from the parsed string.</param>
+        /// <returns>A boolean indicating if the parse was successful.</returns>
+        public static bool TryParse(string value, out Guid guid)
+        {
+            return TryParse(value, out guid, strict: false);
+        }
+
+        /// <summary>
+        /// Tries to parse the value as a <see cref="ShortGuid"/> or <see cref="System.Guid"/> string, and outputs the underlying <see cref="Guid"/> value.
+        ///
+        /// <para>The difference between TryParse and TryDecode:</para>
+        /// <list type="number">
+        ///     <item>
         ///         <term><see cref="TryParse(string, out ShortGuid, bool)"/></term>
         ///         <description>Tries to parse as a <see cref="ShortGuid"/> before attempting parsing as a <see cref="System.Guid"/>, outputs the actual <see cref="ShortGuid"/> instance.</description>
         ///     </item>
@@ -347,7 +438,7 @@ namespace CSharpVitamins
         /// <param name="guid">A new <see cref="System.Guid"/> instance from the parsed string.</param>
         /// <param name="strict">If true the re-encoded result has to exactly match the input <paramref name="value"/>; if false any valid base64 string will be accepted.</param>
         /// <returns>A boolean indicating if the parse was successful.</returns>
-        public static bool TryParse(string value, out Guid guid, bool strict = false)
+        public static bool TryParse(string value, out Guid guid, bool strict)
         {
             // Try a ShortGuid string.
             if (ShortGuid.TryDecode(value, out guid, strict))

--- a/CSharpVitamins.ShortGuid/ShortGuid.cs
+++ b/CSharpVitamins.ShortGuid/ShortGuid.cs
@@ -15,7 +15,7 @@ namespace CSharpVitamins
     public struct ShortGuid
     {
         /// <summary>
-        /// A read-only instance of the ShortGuid struct whose value is guaranteed to be all zeroes i.e. equivilent
+        /// A read-only instance of the ShortGuid struct whose value is guaranteed to be all zeroes i.e. equivalent
         /// to <see cref="Guid.Empty"/>.
         /// </summary>
         public static readonly ShortGuid Empty = new ShortGuid(Guid.Empty);
@@ -25,8 +25,8 @@ namespace CSharpVitamins
 
         /// <summary>
         /// Creates a new instance with the given URL-safe Base64 encoded string.
-        /// See also <seealso cref="ShortGuid.TryParse(string, out ShortGuid)"/> which will try to coerce the
-        /// the value from URL-safe Base64 or normal Guid string
+        /// <para>See also <seealso cref="ShortGuid.TryParse(string, out ShortGuid)"/> which will try to coerce the
+        /// the value from URL-safe Base64 or normal Guid string.</para>
         /// </summary>
         /// <param name="value">A ShortGuid encoded string e.g. URL-safe Base64.</param>
         public ShortGuid(string value)
@@ -63,7 +63,7 @@ namespace CSharpVitamins
 
         /// <summary>
         /// Returns a value indicating whether this instance and a specified object represent the same type and value.
-        /// Compares for equality against other string, Guid and ShortGuid types.
+        /// <para>Compares for equality against other string, Guid and ShortGuid types.</para>
         /// </summary>
         /// <param name="obj"></param>
         /// <returns></returns>
@@ -137,6 +137,14 @@ namespace CSharpVitamins
         /// <summary>
         /// Decodes the given value to a <see cref="System.Guid"/>.
         /// <para>See also <seealso cref="TryDecode(string, out Guid)"/> or <seealso cref="TryParse(string, out Guid)"/>.</para>
+        /// 
+        /// <para>NB: This method does not check if the result Guid is strictly correct. It accepts any Base64 encoded
+        /// string, allowing a) longer strings to be parsed where the remaining data is ignored and b) the end of a
+        /// Base64 string to be tweaked where it still produces that same byte array to create the underlying Guid.
+        /// Effectively there is "unused space" in the Base64 string which is ignored.
+        /// </para>
+        /// <para>See the strict version of this method which ensures the value being passed in is valid. Strict decoding
+        /// will be on by default from version 2+.</para>
         /// </summary>
         /// <param name="value">The ShortGuid encoded string to decode.</param>
         /// <returns>A new <see cref="System.Guid"/> instance from the parsed string.</returns>
@@ -152,7 +160,10 @@ namespace CSharpVitamins
         /// <param name="value">The ShortGuid encoded string to decode.</param>
         /// <param name="strict">If true the re-encoded result has to exactly match the input <paramref name="value"/>; if false any valid base64 string will be accepted.</param>
         /// <returns>A new <see cref="System.Guid"/> instance from the parsed string.</returns>
-        /// <exception cref="FormatException">If <paramref name="value"/> is no valid base64 string (<seealso cref="Convert.FromBase64String(string)"/>) or if the <paramref name="strict"/> flag is set and the re-encoded output doesn't match <paramref name="value"/>.</exception>
+        /// <exception cref="FormatException">
+        /// If <paramref name="value"/> is not a valid Base64 string (<seealso cref="Convert.FromBase64String(string)"/>)
+        /// or if the <paramref name="strict"/> flag is set and the decoded guid doesn't strictly match the input <paramref name="value"/>.
+        /// </exception>
         public static Guid Decode(string value, bool strict)
         {
             string base64 = value
@@ -165,11 +176,14 @@ namespace CSharpVitamins
             if (!strict)
                 return guid;
 
-            var reencodedOutput = Encode(guid);
-            if (reencodedOutput == value)
+            var sanityCheck = Encode(guid);
+            if (sanityCheck == value)
                 return guid;
 
-            throw new FormatException($"The string '{value}' is a valid base64 string but doesn't match the re-encoded {nameof(ShortGuid)} '{reencodedOutput}'.");
+            throw new FormatException(
+                $"Invalid strict ShortGuid encoded string. The string '{value}' is valid URL-safe Base64, " +
+                $"but failed a round-trip test expecting '{sanityCheck}'."
+            );
         }
 
         /// <summary>
@@ -190,6 +204,12 @@ namespace CSharpVitamins
         ///         <description>Tries to parse as a <see cref="ShortGuid"/> only, but outputs the result as a <see cref="System.Guid"/> - this method.</description>
         ///     </item>
         /// </list>
+        /// 
+        /// <para>NB: This method does not check if the result Guid is strictly correct. It accepts any Base64 encoded
+        /// string, allowing a) longer strings to be parsed where the remaining data is ignored and b) the end of a
+        /// Base64 string to be tweaked where it still produces that same byte array to create the underlying Guid.
+        /// Effectively there is "unused space" in the Base64 string which is ignored.
+        /// </para>
         /// </summary>
         /// <param name="value">The ShortGuid encoded string to decode.</param>
         /// <param name="guid">A new <see cref="System.Guid"/> instance from the parsed string.</param>
@@ -336,6 +356,12 @@ namespace CSharpVitamins
         ///         <description>Tries to parse as a <see cref="ShortGuid"/> only, but outputs the result as a <see cref="System.Guid"/>.</description>
         ///     </item>
         /// </list>
+        /// 
+        /// <para>NB: This method does not check if the result Guid is strictly correct. It accepts any Base64 encoded
+        /// string, allowing a) longer strings to be parsed where the remaining data is ignored and b) the end of a
+        /// Base64 string to be tweaked where it still produces that same byte array to create the underlying Guid.
+        /// Effectively there is "unused space" in the Base64 string which is ignored.
+        /// </para>
         /// </summary>
         /// <param name="value">The ShortGuid encoded string or string representation of a Guid.</param>
         /// <param name="shortGuid">A new <see cref="ShortGuid"/> instance from the parsed string.</param>
@@ -406,6 +432,12 @@ namespace CSharpVitamins
         ///         <description>Tries to parse as a <see cref="ShortGuid"/> only, but outputs the result as a <see cref="System.Guid"/>.</description>
         ///     </item>
         /// </list>
+        /// 
+        /// <para>NB: This method does not check if the result Guid is strictly correct. It accepts any Base64 encoded
+        /// string, allowing a) longer strings to be parsed where the remaining data is ignored and b) the end of a
+        /// Base64 string to be tweaked where it still produces that same byte array to create the underlying Guid.
+        /// Effectively there is "unused space" in the Base64 string which is ignored.
+        /// </para>
         /// </summary>
         /// <param name="value">The ShortGuid encoded string or string representation of a Guid.</param>
         /// <param name="guid">A new <see cref="System.Guid"/> instance from the parsed string.</param>

--- a/CSharpVitamins.ShortGuid/ShortGuid.cs
+++ b/CSharpVitamins.ShortGuid/ShortGuid.cs
@@ -20,8 +20,8 @@ namespace CSharpVitamins
         /// </summary>
         public static readonly ShortGuid Empty = new ShortGuid(Guid.Empty);
 
-        private Guid underlyingGuid;
-        private string encodedString;
+        Guid underlyingGuid;
+        string encodedString;
 
         /// <summary>
         /// Creates a new instance with the given URL-safe Base64 encoded string.
@@ -319,6 +319,7 @@ namespace CSharpVitamins
                 shortGuid = guid;
                 return true;
             }
+
             shortGuid = ShortGuid.Empty;
             return false;
         }


### PR DESCRIPTION
As discussed in https://github.com/csharpvitamins/CSharpVitamins.ShortGuid/pull/4#issuecomment-689254811 I added an optional boolean parameter that allows to enforce strict decoding.