### PR TITLE
Feature/always strict

### DIFF
--- a/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
+++ b/CSharpVitamins.ShortGuid.Tests/ShortGuidFacts.cs
@@ -38,20 +38,20 @@ namespace Tests
         [Fact]
         void StrictDecode_parses_valid_shortGuid_strict_off()
         {
-            ShortGuid.Decode(SampleShortGuidString, strict: false);
+            ShortGuid.Decode(SampleShortGuidString);
         }
 
         [Fact]
         void StrictDecode_parses_valid_shortGuid_strict_on()
         {
-            ShortGuid.Decode(SampleShortGuidString, strict: true);
+            ShortGuid.Decode(SampleShortGuidString);
         }
 
         [Fact]
         void Decode_does_not_parse_longer_base64_string()
         {
             Assert.Throws<ArgumentException>(
-                () => ShortGuid.Decode(LongerBase64String, strict: false)
+                () => ShortGuid.Decode(LongerBase64String)
                 );
         }
 
@@ -59,34 +59,31 @@ namespace Tests
         void StrictDecode_does_not_parse_longer_base64_string()
         {
             Assert.Throws<ArgumentException>(
-                () => ShortGuid.Decode(LongerBase64String, strict: true)
+                () => ShortGuid.Decode(LongerBase64String)
                 );
         }
 
         [Fact]
         void invalid_strings_must_not_return_true_on_try_parse_with_strict_true()
         {
-            // loose parsing should return true
-            Assert.True(ShortGuid.TryParse(InvalidSampleShortGuidString, out ShortGuid looseSguid, strict: false));
+            // try parse should return false
+            Assert.False(ShortGuid.TryParse(InvalidSampleShortGuidString, out ShortGuid strictSguid));
 
-            // strict parsing should return false
-            Assert.False(ShortGuid.TryParse(InvalidSampleShortGuidString, out ShortGuid strictSguid, strict: true));
-
-            // decode with strict should throw
+            // decode should throw
             Assert.Throws<FormatException>(
-                () => ShortGuid.Decode(InvalidSampleShortGuidString, strict: true)
+                () => ShortGuid.Decode(InvalidSampleShortGuidString)
                 );
 
-            // does not throw an exception because strict defaults to false
-            Guid looseDecodedSguid = ShortGuid.Decode(InvalidSampleShortGuidString);
-
-            Assert.Equal((Guid)looseSguid, looseDecodedSguid);
+            // .ctor should throw
+            Assert.Throws<FormatException>(
+                () => new ShortGuid(InvalidSampleShortGuidString)
+                );
         }
 
         [Fact]
         void ctor_throws_when_trying_to_decode_guid_string()
         {
-            Assert.Throws<FormatException>(
+            Assert.Throws<ArgumentException>(
                 () => new ShortGuid(SampleGuidString)
                 );
         }
@@ -153,8 +150,12 @@ namespace Tests
         [Fact]
         void Decode_fails_on_unexpected_string()
         {
-            Assert.Throws<FormatException>(
+            Assert.Throws<ArgumentException>(
                 () => ShortGuid.Decode("Am I valid?")
+                );
+
+            Assert.Throws<FormatException>(
+                () => ShortGuid.Decode("I am 22characters long")
                 );
         }
 

--- a/CSharpVitamins.ShortGuid/CSharpVitamins.ShortGuid.csproj
+++ b/CSharpVitamins.ShortGuid/CSharpVitamins.ShortGuid.csproj
@@ -6,13 +6,31 @@
     <RootNamespace>CSharpVitamins</RootNamespace>
     <Authors>Dave Transom</Authors>
     <Company>CSharpVitamins</Company>
-    <Description>A convenience wrapper struct for dealing with URL-safe Base64 encoded globally unique identifiers (GUID), making a shorter string value (22 vs 36 characters long).</Description>
+    <Description>
+A convenience wrapper struct for dealing with URL-safe Base64 encoded globally unique identifiers (GUID),
+making a shorter string value (22 vs 36 characters long).
+
+As of version 2.0.0, `ShortGuid` performs a sanity check when decoding strings to ensure they haven't been
+tampered with, i.e. allowing the end of a Base64 string to be tweaked where it still produces that same
+byte array to create the underlying Guid. Effectively there is "unused space" in the Base64 string which is
+ignored, but will now result in an `FormatException` being thrown.
+
+ShortGuid will never produce an invalid string, however if one is supplied, it could result in an unintended
+collision where multiple URL-safe Base64 strings can point to the same Guid. To avoid this uncertainty, a
+round-trip check is performed to ensure a 1-1 match with the input string.
+
+Stick with version 1.1.0 if you require the old behaviour with opt-in strict parsing.
+    </Description>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/csharpvitamins/csharpvitamins.shortguid/</PackageProjectUrl>
     <PackageLicenseExpression></PackageLicenseExpression>
     <RepositoryUrl>https://github.com/csharpvitamins/csharpvitamins.shortguid/</RepositoryUrl>
-    <PackageTags>Guid ShortGuid Identifiers Base64</PackageTags>
+    <PackageTags>Guid ShortGuid Identifiers Base64 CSharpVitamins</PackageTags>
     <PackageReleaseNotes>
+- 2.0.0 Strict is now always on.
+        Reduces surface area that exposed `strict` parsing options.
+        Stick with `v1.1.0` if you require the loose form of decoding.
+
 - 1.1.0 Adds overloads for strict parsing to (Try)Decode/Parse methods. Default: strict=false for backwards compatibility.
         Signals intent to move to strict only parsing in version 2+.
 - 1.0.3 Improves documentation.
@@ -22,7 +40,7 @@
 - 1.0.0 Initial release.
 </PackageReleaseNotes>
     <Copyright>Copyright 2007</Copyright>
-    <Version>1.1.0</Version>
+    <Version>2.0.0</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/CSharpVitamins.ShortGuid/ShortGuid.cs
+++ b/CSharpVitamins.ShortGuid/ShortGuid.cs
@@ -210,6 +210,83 @@ namespace CSharpVitamins
             }
         }
 
+        /// <summary>
+        /// Tries to parse the value as a <see cref="ShortGuid"/> or <see cref="System.Guid"/> string, and outputs an actual <see cref="ShortGuid"/> instance.
+        ///
+        /// <para>The difference between TryParse and TryDecode:</para>
+        /// <list type="number">
+        ///     <item>
+        ///         <term><see cref="TryParse(string, out ShortGuid)"/></term>
+        ///         <description>Tries to parse as a <see cref="ShortGuid"/> before attempting parsing as a <see cref="System.Guid"/>, outputs the actual <see cref="ShortGuid"/> instance - this method.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="TryParse(string, out Guid)"/></term>
+        ///         <description>Tries to parse as a <see cref="ShortGuid"/> before attempting parsing as a <see cref="System.Guid"/>, outputs the underlying <see cref="System.Guid"/>.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="TryDecode(string, out Guid)"/></term>
+        ///         <description>Tries to parse as a <see cref="ShortGuid"/> only, but outputs the result as a <see cref="System.Guid"/>.</description>
+        ///     </item>
+        /// </list>
+        /// </summary>
+        /// <param name="value">The ShortGuid encoded string or string representation of a Guid.</param>
+        /// <param name="shortGuid">A new <see cref="ShortGuid"/> instance from the parsed string.</param>
+        public static bool TryParse(string value, out ShortGuid shortGuid)
+        {
+            // Try a ShortGuid string.
+            if (ShortGuid.TryDecode(value, out var guid))
+            {
+                shortGuid = guid;
+                return true;
+            }
+
+            // Try a Guid string.
+            if (Guid.TryParse(value, out guid))
+            {
+                shortGuid = guid;
+                return true;
+            }
+
+            shortGuid = ShortGuid.Empty;
+            return false;
+        }
+
+        /// <summary>
+        /// Tries to parse the value as a <see cref="ShortGuid"/> or <see cref="System.Guid"/> string, and outputs the underlying <see cref="Guid"/> value.
+        ///
+        /// <para>The difference between TryParse and TryDecode:</para>
+        /// <list type="number">
+        ///     <item>
+        ///         <term><see cref="TryParse(string, out ShortGuid)"/></term>
+        ///         <description>Tries to parse as a <see cref="ShortGuid"/> before attempting parsing as a <see cref="System.Guid"/>, outputs the actual <see cref="ShortGuid"/> instance.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="TryParse(string, out Guid)"/></term>
+        ///         <description>Tries to parse as a <see cref="ShortGuid"/> before attempting parsing as a <see cref="System.Guid"/>, outputs the underlying <see cref="System.Guid"/> - this method.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="TryDecode(string, out Guid)"/></term>
+        ///         <description>Tries to parse as a <see cref="ShortGuid"/> only, but outputs the result as a <see cref="System.Guid"/>.</description>
+        ///     </item>
+        /// </list>
+        /// </summary>
+        /// <param name="value">The ShortGuid encoded string or string representation of a Guid.</param>
+        /// <param name="guid">A new <see cref="System.Guid"/> instance from the parsed string.</param>
+        /// <returns>A boolean indicating if the parse was successful.</returns>
+        public static bool TryParse(string value, out Guid guid)
+        {
+            // Try a ShortGuid string.
+            if (ShortGuid.TryDecode(value, out guid))
+                return true;
+
+            // Try a Guid string.
+            if (Guid.TryParse(value, out guid))
+                return true;
+
+            guid = Guid.Empty;
+            return false;
+        }
+
         #region Operators
 
         /// <summary>
@@ -291,82 +368,5 @@ namespace CSharpVitamins
         }
 
         #endregion
-
-        /// <summary>
-        /// Tries to parse the value as a <see cref="ShortGuid"/> or <see cref="System.Guid"/> string, and outputs an actual <see cref="ShortGuid"/> instance.
-        ///
-        /// <para>The difference between TryParse and TryDecode:</para>
-        /// <list type="number">
-        ///     <item>
-        ///         <term><see cref="TryParse(string, out ShortGuid)"/></term>
-        ///         <description>Tries to parse as a <see cref="ShortGuid"/> before attempting parsing as a <see cref="System.Guid"/>, outputs the actual <see cref="ShortGuid"/> instance - this method.</description>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="TryParse(string, out Guid)"/></term>
-        ///         <description>Tries to parse as a <see cref="ShortGuid"/> before attempting parsing as a <see cref="System.Guid"/>, outputs the underlying <see cref="System.Guid"/>.</description>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="TryDecode(string, out Guid)"/></term>
-        ///         <description>Tries to parse as a <see cref="ShortGuid"/> only, but outputs the result as a <see cref="System.Guid"/>.</description>
-        ///     </item>
-        /// </list>
-        /// </summary>
-        /// <param name="value">The ShortGuid encoded string or string representation of a Guid.</param>
-        /// <param name="shortGuid">A new <see cref="ShortGuid"/> instance from the parsed string.</param>
-        public static bool TryParse(string value, out ShortGuid shortGuid)
-        {
-            // Try a ShortGuid string.
-            if (ShortGuid.TryDecode(value, out var guid))
-            {
-                shortGuid = guid;
-                return true;
-            }
-
-            // Try a Guid string.
-            if (Guid.TryParse(value, out guid))
-            {
-                shortGuid = guid;
-                return true;
-            }
-
-            shortGuid = ShortGuid.Empty;
-            return false;
-        }
-
-        /// <summary>
-        /// Tries to parse the value as a <see cref="ShortGuid"/> or <see cref="System.Guid"/> string, and outputs the underlying <see cref="Guid"/> value.
-        ///
-        /// <para>The difference between TryParse and TryDecode:</para>
-        /// <list type="number">
-        ///     <item>
-        ///         <term><see cref="TryParse(string, out ShortGuid)"/></term>
-        ///         <description>Tries to parse as a <see cref="ShortGuid"/> before attempting parsing as a <see cref="System.Guid"/>, outputs the actual <see cref="ShortGuid"/> instance.</description>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="TryParse(string, out Guid)"/></term>
-        ///         <description>Tries to parse as a <see cref="ShortGuid"/> before attempting parsing as a <see cref="System.Guid"/>, outputs the underlying <see cref="System.Guid"/> - this method.</description>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="TryDecode(string, out Guid)"/></term>
-        ///         <description>Tries to parse as a <see cref="ShortGuid"/> only, but outputs the result as a <see cref="System.Guid"/>.</description>
-        ///     </item>
-        /// </list>
-        /// </summary>
-        /// <param name="value">The ShortGuid encoded string or string representation of a Guid.</param>
-        /// <param name="guid">A new <see cref="System.Guid"/> instance from the parsed string.</param>
-        /// <returns>A boolean indicating if the parse was successful.</returns>
-        public static bool TryParse(string value, out Guid guid)
-        {
-            // Try a ShortGuid string.
-            if (ShortGuid.TryDecode(value, out guid))
-                return true;
-
-            // Try a Guid string.
-            if (Guid.TryParse(value, out guid))
-                return true;
-
-            guid = Guid.Empty;
-            return false;
-        }
     }
 }

--- a/CSharpVitamins.ShortGuid/ShortGuid.cs
+++ b/CSharpVitamins.ShortGuid/ShortGuid.cs
@@ -10,6 +10,18 @@ namespace CSharpVitamins
     /// <remarks>
     /// What is URL-safe Base64? That's just a Base64 string with well known special characters replaced (/, +)
     /// or removed (==).
+    ///
+    /// <para>NB: As of version 2.0.0, <see cref="ShortGuid.Decode(string)"/> performs a sanity check when decoding
+    /// strings to ensure they haven't been tampered with, i.e. allowing the end of a Base64 string to be tweaked
+    /// where it still produces that same byte array to create the underlying Guid. Effectively there is "unused
+    /// space" in the Base64 string which is ignored, but will now result in an <see cref="FormatException"/> being
+    /// thrown.</para>
+    ///
+    /// <para>ShortGuid will never produce an invalid string, however if one is supplied it, could result in an
+    /// unintended collision where multiple URL-safe Base64 strings can point to the same Guid. To avoid this
+    /// uncertainty, a round-trip check is performed to ensure a 1-1 match with the input string.</para>
+    ///
+    /// <para>Stick with version 1.1.0 if you require the old behaviour with opt-in strict parsing.</para>
     /// </remarks>
     [DebuggerDisplay("{Value}")]
     public struct ShortGuid

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,19 @@ Available on [NuGet](https://www.nuget.org/packages/csharpvitamins.shortguid/). 
 
     PM> Install-Package CSharpVitamins.ShortGuid
 
+### Strict Parsing (v2.0.0)
+As of version 2.0.0, `ShortGuid` performs a sanity check when decoding strings to ensure they haven't been
+tampered with, i.e. allowing the end of a Base64 string to be tweaked where it still produces that same
+byte array to create the underlying Guid. Effectively there is "unused space" in the Base64 string which is
+ignored, but will now result in an `FormatException` being thrown.
 
+`ShortGuid` will never produce an invalid string, however if one is supplied, it could result in an unintended
+collision where multiple URL-safe Base64 strings can point to the same Guid. To avoid this uncertainty, a
+round-trip check is performed to ensure a 1-1 match with the input string.
+
+Stick with version 1.1.0 if you require the old behaviour with opt-in strict parsing.
+
+---
 
 ## The Gist
 


### PR DESCRIPTION
**Breaking change.** 
Strict parsing (introduced in v1.1.0) is now always on, and reduces the additional surface area for loose/strict parsing adding in that release.